### PR TITLE
Add Selection Support

### DIFF
--- a/catma_gitlab/__init__.py
+++ b/catma_gitlab/__init__.py
@@ -5,3 +5,4 @@ from .project_class import CatmaProject
 from .property_class import Property
 from .text_class import Text
 from .annotation_collection_class import AnnotationCollection
+from .selector_class import Selector

--- a/catma_gitlab/selector_class.py
+++ b/catma_gitlab/selector_class.py
@@ -1,0 +1,15 @@
+"""
+References to spans of text, used by annotations.
+"""
+
+class Selector():
+    """
+    A `Selector` represent one of potentially multiple spans targeted by an `Annotation`.
+    """
+    def __init__(self, start: int, end: int, text: str):
+        self.start = start
+        self.end = end
+        self.covered_text = text[start:end]
+
+    def __repr__(self):
+        return f"Selector(start={self.start}, end={self.end}, covered_text={self.covered_text})"


### PR DESCRIPTION
Previously only start and endpoint of annotations where exposed (as far as I could tell). This PR adds the ability to access the individual spans of an annotation.

Depends on #1 